### PR TITLE
Update build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
       - name: Create local changes
         run: |
-          snakemake -c2 --show-failed-logs --use-conda registry/kgs.yaml
+          touch kgs/*.md; snakemake -c2 --show-failed-logs --use-conda registry/kgs.yaml
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
Snakemake won't build dependencies correctly when files have new modification dates in GitHub checkouts.