### PR TITLE
add mermaid configuration per Material for MkDocs documentation

### DIFF
--- a/docs/javascripts/mermaid.mjs
+++ b/docs/javascripts/mermaid.mjs
@@ -1,0 +1,9 @@
+import mermaid from 'https://unpkg.com/mermaid@10.4.0/dist/mermaid.esm.min.mjs';
+
+mermaid.initialize({
+    maxTextSize: 500000
+});
+
+// Important: necessary to make it visible to Material for MkDocs
+window.mermaid = mermaid;
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ extra_css:
 extra_javascript:
   - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js
   - javascripts/tablesort.js
+  - javascripts/mermaid.mjs
 plugins:
   - search
   - mermaid2:


### PR DESCRIPTION
As an attempt to address https://github.com/frink-okn/graph-descriptions/issues/59 when applied to pages in https://frink.renci.org/kg-stats/, this attempts to increase the maximum size in bytes of a graph that Mermaid will render by an order of magnitude.