### PR TITLE
Remove stray link in "Uploading Graphs" page

### DIFF
--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -3,7 +3,6 @@ This section offers assistance for using various OKN Fabric services.
 
 - Learn how to [Setup Your Repo in the Landing Zone](setup.md)
 - Learn how to [Update Your Graph](update.md)
-- Learn how to [Query OKN knowledge graphs](query-page.md) 
 - Learn how to [Update Example Queries](update-queries.md)
 
 


### PR DESCRIPTION
(Somehow this was missed as part of the rearrangement of pages on the site.)