### PR TITLE
update nasa-gesdisc neo4j configuration and associated queries

### DIFF
--- a/docs/registry/neo4j-conf/nasa.yaml
+++ b/docs/registry/neo4j-conf/nasa.yaml
@@ -1,10 +1,12 @@
-base: 'https://nasa-gesdisc.proto-okn.net/kg/'
+base: 'https://purl.org/okn/frink/kg/nasa-gesdisc/'
 mappings:
   globalId:
     type: 'http://www.w3.org/2001/XMLSchema#string'
-  doi:
-    type: 'http://www.w3.org/2001/XMLSchema#string'
     iri: 'http://purl.org/dc/terms/identifier'
+  doi:
+    type: 'IRI'
+    iri: 'http://purl.org/ontology/bibo/doi'
+    base: 'http://dx.doi.org/'
   shortName:
     type: 'http://www.w3.org/2001/XMLSchema#string'
     iri: 'http://www.w3.org/2000/01/rdf-schema#label'
@@ -20,31 +22,20 @@ mappings:
     type: 'http://www.w3.org/2001/XMLSchema#string'
   temporalFrequency:
     type: 'http://www.w3.org/2001/XMLSchema#string'
+    iri: 'http://purl.org/dc/terms/accrualPeriodicity'
   temporalExtentStart:
     type: 'http://www.w3.org/2001/XMLSchema#dateTime'
-    iri: 'http://purl.org/dc/terms/date'
+    iri: 'https://schema.org/startDate'
   temporalExtentEnd:
     type: 'http://www.w3.org/2001/XMLSchema#dateTime'
-    iri: 'http://purl.org/dc/terms/date'
-  nwCorner_crs:
-    type: 'http://www.w3.org/2001/XMLSchema#string'
-  nwCorner_latitude:
-    type: 'http://www.w3.org/2001/XMLSchema#decimal'
-  nwCorner_longitude:
-    type: 'http://www.w3.org/2001/XMLSchema#decimal'
-  seCorner_crs:
-    type: 'http://www.w3.org/2001/XMLSchema#string'
-  seCorner_latitude:
-    type: 'http://www.w3.org/2001/XMLSchema#decimal'
-  seCorner_longitude:
-    type: 'http://www.w3.org/2001/XMLSchema#decimal'
+    iri: 'https://schema.org/endDate'
   landingPageUrl:
     type: http://www.w3.org/2001/XMLSchema#anyURI
-  pagerank_publication_dataset:
-    type: 'http://www.w3.org/2001/XMLSchema#float'
+    iri: http://www.w3.org/ns/dcat#landingPage
   DOI:
-    type: 'http://www.w3.org/2001/XMLSchema#string'
-    iri: 'http://purl.org/dc/terms/identifier'
+    type: 'IRI'
+    iri: 'http://purl.org/ontology/bibo/doi'
+    base: 'http://dx.doi.org/'
   title:
     type: 'http://www.w3.org/2001/XMLSchema#string'
     iri: 'https://schema.org/title'
@@ -58,5 +49,7 @@ mappings:
     iri: 'http://www.w3.org/2000/01/rdf-schema#label'
   Type:
     type: 'http://www.w3.org/2001/XMLSchema#string'
+    iri: 'http://purl.org/dc/terms/type'
   url:
     type: http://www.w3.org/2001/XMLSchema#anyURI
+    iri: 'https://schema.org/url'

--- a/docs/registry/queries/nasa-gesdisc-kg/count-publications-use-each-dataset.rq
+++ b/docs/registry/queries/nasa-gesdisc-kg/count-publications-use-each-dataset.rq
@@ -2,7 +2,7 @@
 #+ tags:
 #+   - nasa-gesdisc-kg
 
-PREFIX schema: <https://nasa-gesdisc.proto-okn.net/kg/schema/>
+PREFIX schema: <https://purl.org/okn/frink/kg/nasa-gesdisc/schema/>
 SELECT ?Dataset (COUNT (DISTINCT ?Publication) AS ?PublicationCount)
 WHERE {
 	?Publication schema:USES_DATASET ?Dataset

--- a/docs/registry/queries/nasa-gesdisc-kg/datasets-science-keywords.rq
+++ b/docs/registry/queries/nasa-gesdisc-kg/datasets-science-keywords.rq
@@ -2,7 +2,7 @@
 #+ tags:
 #+   - nasa-gesdisc-kg
 
-PREFIX schema: <https://nasa-gesdisc.proto-okn.net/kg/schema/>
+PREFIX schema: <https://purl.org/okn/frink/kg/nasa-gesdisc/schema/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT *
 WHERE {

--- a/docs/registry/queries/nasa-gesdisc-kg/frequent-sciencekeywords-wikidata.rq
+++ b/docs/registry/queries/nasa-gesdisc-kg/frequent-sciencekeywords-wikidata.rq
@@ -2,7 +2,7 @@
 #+ tags:
 #+   - federation
 
-PREFIX schema: <https://nasa-gesdisc.proto-okn.net/kg/schema/>
+PREFIX schema: <https://purl.org/okn/frink/kg/nasa-gesdisc/schema/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT ?ScienceKeyword (COUNT (DISTINCT ?Publication) AS ?PublicationCount)
 WHERE {

--- a/docs/registry/queries/nasa-gesdisc-kg/frequent-sciencekeywords.rq
+++ b/docs/registry/queries/nasa-gesdisc-kg/frequent-sciencekeywords.rq
@@ -2,10 +2,10 @@
 #+ tags:
 #+   - nasa-gesdisc-kg
 
-PREFIX schema: <https://nasa-gesdisc.proto-okn.net/kg/schema/>
+PREFIX schema: <https://purl.org/okn/frink/kg/nasa-gesdisc/schema/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT ?ScienceKeyword (COUNT (DISTINCT ?Publication) AS ?PublicationCount)
-WHERE { 
+WHERE {
         ?Publication schema:USES_DATASET ?Dataset .
         ?Dataset schema:HAS_SCIENCEKEYWORD ?Keyword .
         ?Keyword rdfs:label ?ScienceKeyword

--- a/docs/registry/queries/nasa-gesdisc-kg/publications-datasets-used.rq
+++ b/docs/registry/queries/nasa-gesdisc-kg/publications-datasets-used.rq
@@ -2,7 +2,7 @@
 #+ tags:
 #+   - nasa-gesdisc-kg
 
-PREFIX schema: <https://nasa-gesdisc.proto-okn.net/kg/schema/>
+PREFIX schema: <https://purl.org/okn/frink/kg/nasa-gesdisc/schema/>
 SELECT *
 WHERE {
 	?Publication schema:USES_DATASET ?Dataset

--- a/docs/registry/queries/nasa-gesdisc-kg/publications-using-dataset-wikidata.rq
+++ b/docs/registry/queries/nasa-gesdisc-kg/publications-using-dataset-wikidata.rq
@@ -3,13 +3,14 @@
 #+   - federation
 
 PREFIX sdo: <https://schema.org/>
-PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+PREFIX wdtn: <http://www.wikidata.org/prop/direct-normalized/>
 PREFIX dct: <http://purl.org/dc/terms/>
-PREFIX schema: <https://nasa-gesdisc.proto-okn.net/kg/schema/>
+PREFIX bibo: <http://purl.org/ontology/bibo/doi>
+PREFIX schema: <https://purl.org/okn/frink/kg/nasa-gesdisc/schema/>
 SELECT ?item ?identifier ?title
 WHERE {
 	?Publication schema:USES_DATASET <https://nasa-gesdisc.proto-okn.net/kg/node/186> .
-    ?Publication dct:identifier ?identifier ; sdo:title ?title .
-    ?item wdt:P356 ?identifier .
+    ?Publication bibo:doi ?identifier ; sdo:title ?title .
+    ?item wdtn:P356 ?identifier .
 }
 LIMIT 25

--- a/docs/registry/queries/nasa-gesdisc-kg/pubs-by-year-title.rq
+++ b/docs/registry/queries/nasa-gesdisc-kg/pubs-by-year-title.rq
@@ -5,7 +5,7 @@
 PREFIX time: <http://www.w3.org/2006/time#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX schema: <https://schema.org/>
-PREFIX gesdisc: <https://nasa-gesdisc.proto-okn.net/kg/schema/>
+PREFIX gesdisc: <https://purl.org/okn/frink/kg/nasa-gesdisc/schema/>
 SELECT ?pub ?year ?title   {
   ?pub a gesdisc:Publication .
   ?pub time:year ?year .


### PR DESCRIPTION
As part of addressing https://github.com/frink-okn/okn-registry/issues/326, I have made some adjustments to the configuration for the NASA-GESDISC graph in order to convert to more existing RDF predicates and additionally render DOIs as IRIs.

(There are other adjustments I'd like to make happen, both to handle relationships between entities and to transform certain types of values, but those will require changes to https://github.com/frink-okn/neo4j-json-to-ttl/.)