### PR TITLE
Fix typo in bio101 description and update URLs

### DIFF
--- a/docs/registry/kgs/bio101.md
+++ b/docs/registry/kgs/bio101.md
@@ -1,12 +1,13 @@
+---
 template: overrides/kg.html
 shortname: bio101
 title: KB Bio 101
-description: A knowledge base creatd from an introductory biology textbook
+description: A knowledge base created from an introductory biology textbook
 stats: https://registry.okn.us/kg-stats/bio101
 homepage: https://www.ai.sri.com/~halo/public/exported-kb/biokb.html
 funding: Project Halo, Vulcan Inc.
-sparql: https://apps.okn.us/bio101/sparql
-tpf: https://apps.okn.us/ldf/bio101
+#sparql: https://apps.okn.us/bio101/sparql
+#tpf: https://apps.okn.us/ldf/bio101
 frink-options:
   lakefs-repo: bio101
   documentation-path: bio101


### PR DESCRIPTION
Corrected a typo in the description and commented out sparql and tpf URLs—until these are deployed.