### PR TITLE
Add license information to biobricks-aopwiki.md

### DIFF
--- a/docs/registry/kgs/biobricks-aopwiki.md
+++ b/docs/registry/kgs/biobricks-aopwiki.md
@@ -15,6 +15,7 @@ contact:
   email: tom@insilica.co
   github: "tomlue"
   label: "Tom Luechtefeld"
+license: "https://creativecommons.org/licenses/by-sa/4.0/"
 ---
 The BioBricks AOP-Wiki knowledge graph serves toxicologists, regulatory scientists, and environmental health researchers by providing structured representations of Adverse Outcome Pathways (AOPs) that link molecular initiating events to adverse health outcomes. This knowledge graph contains 493 AOPs, 1,469 key events, and 2,060 key event relationships, totaling 184,303 triples that capture the mechanistic understanding of chemical toxicity pathways. The dataset integrates chemical entities (including CHEMINF molecular descriptors), biological processes (GO terms), and organism/organ/cell-type contexts, with extensive cross-references to ChEBI, ChEMBL, PubChem, KEGG, and Wikidata through 13,692 exact matches and additional identifier mappings. Licensed under CC-BY-SA-1.0 with regular updates (last modified November 2024), the graph is derived from the collaborative AOP-Wiki project and is accessible via a SPARQL endpoint through FRINK, enabling federated queries for chemical hazard assessment and predictive toxicology applications.
 


### PR DESCRIPTION
Added license information for the BioBricks AOP-Wiki knowledge graph. This license is based on what I think the original AOP-Wiki provides.