### PR TITLE
Include license details in biobricks-mesh.md

### DIFF
--- a/docs/registry/kgs/biobricks-mesh.md
+++ b/docs/registry/kgs/biobricks-mesh.md
@@ -15,6 +15,7 @@ contact:
   email: tom@insilica.co
   github: "tomlue"
   label: "Tom Luechtefeld"
+license: "https://creativecommons.org/publicdomain/zero/1.0/"
 ---
 BioBricks MeSH is an open knowledge graph providing the complete Medical Subject Headings (MeSH) controlled vocabulary from the U.S. National Library of Medicine in RDF format for biomedical researchers, data scientists, and information professionals. The graph contains over 18.1 million triples representing 2.4 million biomedical entities organized into 862,579 terms, 464,362 concepts, and 249,243 chemical substance records alongside 66,110 organisms, 29,940 topical descriptors, and 6,750 diseases. The hierarchical structure is maintained through 80,096 tree numbers with parent-child relationships and complex concept mappings. Entities are richly labeled with standard rdfs:label properties (achieving 98%+ coverage across major classes) and include temporal metadata with the latest revisions dating to January 2023. Licensed as public domain (CC0-1.0), the dataset is available through a SPARQL endpoint at FRINK, enabling direct federated queries with other biomedical knowledge graphs that reference MeSH identifiers.
 


### PR DESCRIPTION
Added license information for the BioBricks MeSH dataset.