### PR TITLE
Add license information to gene-expression-atlas-okn.md

### DIFF
--- a/docs/registry/kgs/gene-expression-atlas-okn.md
+++ b/docs/registry/kgs/gene-expression-atlas-okn.md
@@ -17,7 +17,8 @@ contacts:
   label: "Andrew Su"
 - email: plwhetzel@gmail.com
   github: "twhetzel"
-  label: "Trish Whetzel" 
+  label: "Trish Whetzel"
+license: "https://creativecommons.org/licenses/by/4.0/"
 ---
 
 Selected studies from the Gene Expression Atlas (https://www.ebi.ac.uk/gxa/home).


### PR DESCRIPTION
Added license information for Gene Expression Atlas. Consistent with https://www.ebi.ac.uk/gxa/licence.html.